### PR TITLE
Fix url key of createFileOutput options for streaming

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -93,7 +93,7 @@ function createReadableStream({ url, fetch, options = {} }) {
           typeof data === "string" &&
           (data.startsWith("https:") || data.startsWith("data:"))
         ) {
-          data = createFileOutput({ data, fetch });
+          data = createFileOutput({ url: data, fetch });
         }
         controller.enqueue(new ServerSentEvent(event.event, data, event.id));
 


### PR DESCRIPTION
Currently, if you try to stream files you get a FileOutput instance in the following state:
```javascript
FileOutput {
  locked: false,
  [state]: 'errored',
  [supportsBYOB]: false,
  [length]: undefined
}
```
This is because a `{ data, fetch }` object is passed to `createFileOutput` which expect a `{ url, fetch }` object.